### PR TITLE
Use calculated delays

### DIFF
--- a/stcgal/protocols.py
+++ b/stcgal/protocols.py
@@ -249,7 +249,7 @@ class StcBaseProtocol:
 
         bit_time = 1.0 / self.ser.baudrate
         byte_time = bit_time * 11.0 # start, 8 data bits, stop, parity
-        clock_safety_factor = 1.05 # additional delay in case clock is slow
+        clock_safety_factor = 2.5 # additional delay in case clock is slow
         time.sleep(byte_time * length * clock_safety_factor)
 
     def set_option(self, name, value):


### PR DESCRIPTION
Some serial drivers don't handle draining the transmit buffer
correctly. This has been handled with a long delay so far, which might
be problematic. There's a race condition with some protocol versions.

Until STC15, the baud rate switch is initiated with a command sent by
stcgal, which is replied to by the MCU with the new baud rate. So the
switch of the baud rate has to be done after the command has finished
transmission, but before the MCU has started to transmit the response.

This change calculates the minimum delay needed (with some tolerance
added) so that it's unlikely that the baud rate switch will happen
too late.