### PR TITLE
add tqdm as required package. Otherwise missing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 before_install:
   - sudo apt install rpm dpkg-dev debhelper dh-python python3-setuptools fakeroot python3-serial python3-yaml
 install:
-  - pip install pyserial pyusb tqdm
+  - pip install pyusb
 script:
   - python setup.py build
   - python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     name = "stcgal",
     version = stcgal.__version__,
     packages = find_packages(exclude=["doc", "tests"]),
-    install_requires = ["pyserial"],
+    install_requires = ["pyserial", "tqdm"],
     extras_require = {
         "usb": ["pyusb>=1.0.0"]
     },


### PR DESCRIPTION
Tried today to pip install the project and noticed there was a missing dependency in setup.py