### PR TITLE
stc15: fix baudrate switching

### DIFF
--- a/doc/MODELS.md
+++ b/doc/MODELS.md
@@ -20,7 +20,7 @@ So far, stcgal was tested with the following MCU models:
 * STC15F104E (BSL version: 6.7Q)
 * STC15F204EA (BSL version: 6.7R)
 * STC15L104W (BSL version: 7.1.4Q)
-* STC15F104W (BSL version: 7.1.4Q)
+* STC15F104W (BSL version: 7.1.4Q and 7.2.5Q)
 * IAP15F2K61S2 (BSL version: 7.1.4S)
 * STC15L2K16S2 (BSL version: 7.2.4S)
 * IAP15L2K61S2 (BSL version: 7.2.5S)

--- a/stcgal/protocols.py
+++ b/stcgal/protocols.py
@@ -1416,7 +1416,10 @@ class Stc15Protocol(Stc15AProtocol):
         sys.stdout.flush()
         packet = bytes([0x01])
         packet += bytes([self.freq_count_24, 0x40])
-        packet += struct.pack(">H", int(65536 - self.mcu_clock_hz / self.baud_transfer / 4))
+        bauds = int(65536 - self.mcu_clock_hz / self.baud_transfer / 4)
+        if bauds >= 65536:
+            raise StcProtocolException("baudrate adjustment failed")
+        packet += struct.pack(">H", bauds)
         iap_wait = self.get_iap_delay(self.mcu_clock_hz)
         packet += bytes([0x00, 0x00, iap_wait])
         self.write_packet(packet)

--- a/stcgal/protocols.py
+++ b/stcgal/protocols.py
@@ -1406,7 +1406,7 @@ class Stc15Protocol(Stc15AProtocol):
         response = self.read_packet()
         if len(response) < 1 or response[0] != 0x01:
             raise StcProtocolException("incorrect magic in handshake packet")
-        time.sleep(0.2)
+        time.sleep(0.1)
         self.ser.baudrate = self.baud_transfer
 
     def switch_baud_ext(self):
@@ -1426,7 +1426,7 @@ class Stc15Protocol(Stc15AProtocol):
         response = self.read_packet()
         if len(response) < 1 or response[0] != 0x01:
             raise StcProtocolException("incorrect magic in handshake packet")
-        time.sleep(0.2)
+        time.sleep(0.1)
         self.ser.baudrate = self.baud_transfer
 
         # for switching back to RC, program factory values


### PR DESCRIPTION
Baudrate switching fixes for both HW and SW UART devices:

* Program secondary SW UART timing parameter correctly. Supposedly this
  controls the sampling position when receiving data.
* Swap around trim range/adjust parameter for HW UART devices (as
  determind by older traces)
* Use correct constant for timing calculations

This should fix some STC15x10xW series MCUs. Compatibility to other
devices might be improved as well.