### PR TITLE
Add option to invert pin reset logic

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -22,8 +22,7 @@ options:
   -h, --help            show this help message and exit
   -e, --erase           only erase flash memory
   -a, --autoreset       cycle power automatically by asserting DTR
-  -i, --invertreset     invert pin reset logic
-  -A {dtr,rts}, --resetpin {dtr,rts}
+  -A {dtr,rts,dtr_inverted,rts_inverted}, --resetpin {dtr,rts,dtr_inverted,rts_inverted}
                         pin to hold down when using --autoreset (default: DTR)
   -r RESETCMD, --resetcmd RESETCMD
                         shell command for board power-cycling (instead of DTR

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -22,6 +22,7 @@ options:
   -h, --help            show this help message and exit
   -e, --erase           only erase flash memory
   -a, --autoreset       cycle power automatically by asserting DTR
+  -i, --invertreset     invert pin reset logic
   -A {dtr,rts}, --resetpin {dtr,rts}
                         pin to hold down when using --autoreset (default: DTR)
   -r RESETCMD, --resetcmd RESETCMD

--- a/stcgal/frontend.py
+++ b/stcgal/frontend.py
@@ -183,7 +183,7 @@ class StcGal:
             return 0
 
         try:
-            self.protocol.connect(autoreset=self.opts.autoreset, resetcmd=self.opts.resetcmd, resetpin=self.opts.resetpin, invertreset=self.opts.invertreset)
+            self.protocol.connect(autoreset=self.opts.autoreset, resetcmd=self.opts.resetcmd, resetpin=self.opts.resetpin)
             if isinstance(self.protocol, StcAutoProtocol):
                 if not self.protocol.protocol_name:
                     raise StcProtocolException("cannot detect protocol")
@@ -263,8 +263,7 @@ def cli():
     exclusives.add_argument("-e", "--erase", help="only erase flash memory", action="store_true")
     parser.add_argument("-a", "--autoreset", help="cycle power automatically by asserting DTR", action="store_true")
     parser.add_argument("-A", "--resetpin", help="pin to hold down when using --autoreset (default: DTR)",
-                        choices=["dtr", "rts"], default="dtr")
-    parser.add_argument("-i", "--invertreset", help="invert autoreset pin logic", action="store_true")
+                        choices=["dtr", "rts", "dtr_inverted", "rts_inverted"], default="dtr")
     parser.add_argument("-r", "--resetcmd",  help="shell command for board power-cycling (instead of DTR assertion)", action="store")
     parser.add_argument("-P", "--protocol", help="protocol version (default: auto)",
                         choices=["stc89", "stc89a", "stc12a", "stc12b", "stc12", "stc15a", "stc15", "stc8", "stc8d", "stc8g", "usb15", "auto"], default="auto")

--- a/stcgal/frontend.py
+++ b/stcgal/frontend.py
@@ -183,7 +183,7 @@ class StcGal:
             return 0
 
         try:
-            self.protocol.connect(autoreset=self.opts.autoreset, resetcmd=self.opts.resetcmd, resetpin=self.opts.resetpin)
+            self.protocol.connect(autoreset=self.opts.autoreset, resetcmd=self.opts.resetcmd, resetpin=self.opts.resetpin, invertreset=self.opts.invertreset)
             if isinstance(self.protocol, StcAutoProtocol):
                 if not self.protocol.protocol_name:
                     raise StcProtocolException("cannot detect protocol")
@@ -264,6 +264,7 @@ def cli():
     parser.add_argument("-a", "--autoreset", help="cycle power automatically by asserting DTR", action="store_true")
     parser.add_argument("-A", "--resetpin", help="pin to hold down when using --autoreset (default: DTR)",
                         choices=["dtr", "rts"], default="dtr")
+    parser.add_argument("-i", "--invertreset", help="invert autoreset pin logic", action="store_true")
     parser.add_argument("-r", "--resetcmd",  help="shell command for board power-cycling (instead of DTR assertion)", action="store")
     parser.add_argument("-P", "--protocol", help="protocol version (default: auto)",
                         choices=["stc89", "stc89a", "stc12a", "stc12b", "stc12", "stc15a", "stc15", "stc8", "stc8d", "stc8g", "usb15", "auto"], default="auto")

--- a/stcgal/protocols.py
+++ b/stcgal/protocols.py
@@ -265,22 +265,25 @@ class StcBaseProtocol(ABC):
     def set_option(self, name, value):
         self.options.set_option(name, value)
 
-    def reset_device(self, resetcmd=False, resetpin=False):
+    def reset_device(self, resetcmd=False, resetpin=False, invertreset=False):
         if not resetcmd:
             print("Cycling power: ", end="")
             sys.stdout.flush()
+
+            # If invertreset is enabled, start with pin at low
+            pin_state = False if invertreset else True
             
             if resetpin == "rts":
-                self.ser.setRTS(True)
+                self.ser.setRTS(pin_state)
             else:
-                self.ser.setDTR(True)
+                self.ser.setDTR(pin_state)
 				
             time.sleep(0.25)
             
             if resetpin == "rts":
-                self.ser.setRTS(False)
+                self.ser.setRTS(not pin_state)
             else:
-                self.ser.setDTR(False)
+                self.ser.setDTR(not pin_state)
 				
             time.sleep(0.030)
             print("done")
@@ -291,7 +294,7 @@ class StcBaseProtocol(ABC):
         print("Waiting for MCU: ", end="")
         sys.stdout.flush()
 
-    def connect(self, autoreset=False, resetcmd=False, resetpin=False):
+    def connect(self, autoreset=False, resetcmd=False, resetpin=False, invertreset=False):
         """Connect to MCU and initialize communication.
 
         Set up serial port, send sync sequence and get part info.
@@ -310,7 +313,7 @@ class StcBaseProtocol(ABC):
         self.ser.flushInput()
 
         if autoreset:
-            self.reset_device(resetcmd, resetpin)
+            self.reset_device(resetcmd, resetpin, invertreset)
         else:
             print("Waiting for MCU, please cycle power: ", end="")
             sys.stdout.flush()

--- a/stcgal/protocols.py
+++ b/stcgal/protocols.py
@@ -269,21 +269,26 @@ class StcBaseProtocol(ABC):
         if not resetcmd:
             print("Cycling power: ", end="")
             sys.stdout.flush()
-
-            # If invertreset is enabled, start with pin at low
-            pin_state = False if invertreset else True
             
             if resetpin == "rts":
-                self.ser.setRTS(pin_state)
-            else:
-                self.ser.setDTR(pin_state)
+                self.ser.setRTS(True)
+            elif resetpin == "dtr":
+                self.ser.setDTR(True)
+            elif resetpin == "rts_inverted":
+                self.ser.setRTS(False)
+            else: # dtr_inverted
+                self.ser.setDTR(False)
 				
             time.sleep(0.25)
             
             if resetpin == "rts":
-                self.ser.setRTS(not pin_state)
-            else:
-                self.ser.setDTR(not pin_state)
+                self.ser.setRTS(False)
+            elif resetpin == "dtr":
+                self.ser.setDTR(False)
+            elif resetpin == "rts_inverted":
+                self.ser.setRTS(True)
+            else: # dtr_inverted
+                self.ser.setDTR(True)
 				
             time.sleep(0.030)
             print("done")
@@ -294,7 +299,7 @@ class StcBaseProtocol(ABC):
         print("Waiting for MCU: ", end="")
         sys.stdout.flush()
 
-    def connect(self, autoreset=False, resetcmd=False, resetpin=False, invertreset=False):
+    def connect(self, autoreset=False, resetcmd=False, resetpin=False):
         """Connect to MCU and initialize communication.
 
         Set up serial port, send sync sequence and get part info.
@@ -313,7 +318,7 @@ class StcBaseProtocol(ABC):
         self.ser.flushInput()
 
         if autoreset:
-            self.reset_device(resetcmd, resetpin, invertreset)
+            self.reset_device(resetcmd, resetpin)
         else:
             print("Waiting for MCU, please cycle power: ", end="")
             sys.stdout.flush()


### PR DESCRIPTION
This PR adds a -i / --invertreset option for the --autoreset function.
One of my boards (made by PRECHIN) requires an inverted assertion of the DTR signal to cycle the power, otherwise it remains powered off.

I originally tried implementing the reset using an external command, but given that the serial port was already opened by stcgal and thus inaccessible to my tool (at least on Windows), I opted for this small change.